### PR TITLE
Use backend-provided period length in PeriodStatusCard subtext

### DIFF
--- a/src/screens/period/components/PeriodStatusCard.tsx
+++ b/src/screens/period/components/PeriodStatusCard.tsx
@@ -20,6 +20,11 @@ const PeriodStatusCard: React.FC<Props> = ({
 }) => {
   const { theme } = useTheme();
   const styles = useMemo(() => createStyles(theme), [theme]);
+  const expectedPeriodLength =
+    status.expectedEndDay ??
+    status.cycle?.periodLength ??
+    status.lastCycle?.periodLength ??
+    5;
 
   const getStatusContent = () => {
     switch (status.status) {
@@ -28,7 +33,7 @@ const PeriodStatusCard: React.FC<Props> = ({
           emoji: "🌸",
           label: isPartnerView ? "PARTNER'S PERIOD" : "CURRENTLY ON PERIOD",
           days: (status.daysSinceStart || 0) + 1,
-          subtext: `Day ${(status.daysSinceStart || 0) + 1} of ~${status.expectedEndDay || 5}`,
+          subtext: `Day ${(status.daysSinceStart || 0) + 1} of ~${expectedPeriodLength}`,
           gradientColors: ["#ff6b9d", "#c44569"] as [string, string],
           chipText: "On Period",
           chipBg: "#ff6b9d20",
@@ -192,4 +197,3 @@ const createStyles = (theme: any) =>
   });
 
 export default PeriodStatusCard;
-


### PR DESCRIPTION
### Motivation
- The period card always displayed `Day X of ~5` which ignored backend-provided period length and made the UI show a constant `5` even when actual data was available.
- The intent is to prefer server-side values for the expected period length when available so the on-period subtext accurately reflects user data.

### Description
- Compute `expectedPeriodLength` in `src/screens/period/components/PeriodStatusCard.tsx` from `status.expectedEndDay`, then `status.cycle?.periodLength`, then `status.lastCycle?.periodLength`, falling back to `5`.
- Replace the hard-coded `5` in the `on_period` subtext with the computed `expectedPeriodLength` so `Day X of ~Y` uses backend values when present.
- Change is limited to the `PeriodStatusCard` component and does not modify other UI behavior.

### Testing
- No automated tests were run for this change.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6960b0d81e188331939be14e5fe4370c)